### PR TITLE
new: [statsApi-userAgent] Added user-agent definition in configuratio…

### DIFF
--- a/INSTALL/INSTALL.ubuntu1804.md
+++ b/INSTALL/INSTALL.ubuntu1804.md
@@ -224,6 +224,7 @@ local.php file:
 + 'statsApi' => [
 +     'baseUrl' => 'http://127.0.0.1:5005',
 +     'apiKey' => '<your-cli-API-key>',
++     'userAgent' => 'MONARC/<MONARC_VERSION_NUMBER>
 + ],
 ];
 ```

--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -79,5 +79,6 @@ return [
     'statsApi' => [
         'baseUrl' => 'http://127.0.0.1:5005',
         'apiKey' => '',
+        'userAgent' => 'MONARC v'. $package_json['version']
     ],
 ];

--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -79,6 +79,6 @@ return [
     'statsApi' => [
         'baseUrl' => 'http://127.0.0.1:5005',
         'apiKey' => '',
-        'userAgent' => 'MONARC v'. $package_json['version']
+        'userAgent' => 'MONARC/'. $package_json['version']
     ],
 ];

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -295,6 +295,13 @@ cd $PATH_TO_MONARC
 echo -e "\n--- Configuration of MONARC database connection ---\n"
 sudo bash -c "cat << EOF > config/autoload/local.php
 <?php
+\$appdir = getenv('APP_DIR') ? getenv('APP_DIR') : '$PATH_TO_MONARC';
+\$string = file_get_contents(\$appdir.'/package.json');
+if(\$string === FALSE) {
+    \$string = file_get_contents('./package.json');
+}
+\$package_json = json_decode(\$string, true);
+
 return [
     'doctrine' => [
         'connection' => [
@@ -319,7 +326,7 @@ return [
 
     'activeLanguages' => ['fr','en','de','nl'],
 
-    'appVersion' => '-master',
+    'appVersion' => \$package_json['version'],
 
     'checkVersion' => false,
     'appCheckingURL' => 'https://version.monarc.lu/check/MONARC',
@@ -339,6 +346,7 @@ return [
     'statsApi' => [
         'baseUrl' => 'http://127.0.0.1:$STATS_PORT',
         'apiKey' => '$apiKey',
+        'userAgent' => 'MONARC v'. \$package_json['version']
     ],
 ];
 EOF"

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -346,7 +346,7 @@ return [
     'statsApi' => [
         'baseUrl' => 'http://127.0.0.1:$STATS_PORT',
         'apiKey' => '$apiKey',
-        'userAgent' => 'MONARC v'. \$package_json['version']
+        'userAgent' => 'MONARC/'. \$package_json['version']
     ],
 ];
 EOF"


### PR DESCRIPTION
…n so that Stats Service will be able to see the version of MONARC requesting the stats data.

## Generic requirements in order to contribute to MONARC:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch
* Any major changes adding a functionality should be disabled by default in the configuration of MONARC


#### What does it do?

If it fixes an existing issue, please use GitHub syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch

